### PR TITLE
Add initial implementation for complexipy to be a pre-commit hook

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Lint
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      # used for generating API
+      SM_DOCKER: samplemetadata:dev
+    defaults:
+      run:
+        shell: bash -eo pipefail -l {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: pre-commit
+        run: pre-commit run --all-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,12 +4,6 @@ on: push
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
-      BUILDKIT_PROGRESS: plain
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      # used for generating API
-      SM_DOCKER: samplemetadata:dev
     defaults:
       run:
         shell: bash -eo pipefail -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+exclude: "migrations/.*"
+default_language_version:
+  python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.8.3
+    hooks:
+      - id: ruff
+      # useful when running pre-commit locally
+        args: ["--fix"]
+
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        args:
+          [
+            --pretty,
+            --show-error-codes,
+            --install-types,
+            --non-interactive,
+          ]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: complexipy
+  name: complexipy
+  description: "Run 'complexipy' for extremely fast calculation of cognitive complexity of Python files"
+  entry: complexipy
+  language: python
+  types_or: [python, pyi, jupyter]
+  args: []
+  require_serial: true
+  additional_dependencies: []
+  minimum_pre_commit_version: "2.9.2"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # complexipy-pre-commit
-A pre-commit hook for complexipy.
+
+A [pre-commit](https://pre-commit.com/) hook for [Complexipy](https://github.com/rohaquinlop/complexipy).
+
+Distributed as a standalone repository to enable installing complexipy via prebuilt wheels from [PyPI](https://pypi.org/project/complexipy/).
+
+### Using complexipy with pre-commit
+
+To run Complexipy's [linter](https://github.com/rohaquinlop/complexipy) via pre-commit, add the following to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+- repo: https://github.com/illusional/complexipy-pre-commit
+  # complexipy version.
+  rev: v0.5.0
+  hooks:
+    # Run the cognitive complexity checker.
+    - id: complexipy
+```
+To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed filetypes:
+
+```yaml
+repos:
+- repo: https://github.com/illusional/complexipy-pre-commit
+  # complexipy version.
+  rev: v0.5.0
+  hooks:
+    # Run the cognitive complexity checker.
+    - id: complexipy
+      types_or: [ python, pyi ]
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run Complexipy's [linter](https://github.com/rohaquinlop/complexipy) via pre-
 repos:
 - repo: https://github.com/illusional/complexipy-pre-commit
   # complexipy version.
-  rev: v0.5.0
+  rev: v1.2.0
   hooks:
     # Run the cognitive complexity checker.
     - id: complexipy
@@ -23,7 +23,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 repos:
 - repo: https://github.com/illusional/complexipy-pre-commit
   # complexipy version.
-  rev: v0.5.0
+  rev: v1.2.0
   hooks:
     # Run the cognitive complexity checker.
     - id: complexipy

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To run Complexipy's [linter](https://github.com/rohaquinlop/complexipy) via pre-
 
 ```yaml
 repos:
-- repo: https://github.com/illusional/complexipy-pre-commit
+- repo: https://github.com/rohaquinlop/complexipy-pre-commit
   # complexipy version.
   rev: v1.2.0
   hooks:
@@ -21,7 +21,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 
 ```yaml
 repos:
-- repo: https://github.com/illusional/complexipy-pre-commit
+- repo: https://github.com/rohaquinlop/complexipy-pre-commit
   # complexipy version.
   rev: v1.2.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "complexipy-pre-commit"
-version = "0.0.0"
+version = "1.2.0"
 dependencies = [
     "complexipy==1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "complexipy-pre-commit"
 version = "0.0.0"
 dependencies = [
-    "complexipy==0.5.0",
+    "complexipy==1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "complexipy-pre-commit"
+version = "0.0.0"
+dependencies = [
+    "complexipy==0.5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "packaging~=23.1",
+]
+
+[tool.ruff]
+line-length = 88


### PR DESCRIPTION
Adds .pre-commit-hooks.yaml file for repos to use complexipy for pre-commit hooks. Note, this relies on https://github.com/rohaquinlop/complexipy/issues/55 to be released (and the version to be bumped) to be valid.

To follow-up later, an automatic workflow that checks the main repository, I don't think the apache 2.0 license of https://github.com/astral-sh/ruff-pre-commit/blob/main/mirror.py is equivalent to MIT (their license is ambiguous).

Thanks @rohaquinlop!