### PR TITLE
Update to version 3.0.0 of complexipy in pyproject.toml and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run Complexipy's [linter](https://github.com/rohaquinlop/complexipy) via pre-
 repos:
 - repo: https://github.com/rohaquinlop/complexipy-pre-commit
   # complexipy version.
-  rev: v2.0.0
+  rev: v3.0.0
   hooks:
     # Run the cognitive complexity checker.
     - id: complexipy
@@ -23,7 +23,7 @@ To avoid running on Jupyter Notebooks, remove `jupyter` from the list of allowed
 repos:
 - repo: https://github.com/rohaquinlop/complexipy-pre-commit
   # complexipy version.
-  rev: v2.0.0
+  rev: v3.0.0
   hooks:
     # Run the cognitive complexity checker.
     - id: complexipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "complexipy-pre-commit"
-version = "2.0.0"
-dependencies = ["complexipy==2.0.0"]
+version = "3.0.0"
+dependencies = ["complexipy==3.0.0"]
 
 [project.optional-dependencies]
 dev = ["packaging~=23.1"]


### PR DESCRIPTION
This pull request updates the `complexipy-pre-commit` repository to use version 3.0.0 of Complexipy, ensuring compatibility with the latest features and improvements.

Version update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Updated the `rev` field in the pre-commit configuration examples to reference Complexipy version 3.0.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R4): Updated the `version` field to 3.0.0 and adjusted dependencies to use `complexipy==3.0.0`.